### PR TITLE
Fix require path

### DIFF
--- a/dialog/poodll.php
+++ b/dialog/poodll.php
@@ -32,7 +32,7 @@
  */
 
 define('NO_MOODLE_COOKIES', false);
-require(__DIR__ . '../../../../../../../config.php');
+require(__DIR__ . '/../../../../../../config.php');
 require_once($CFG->dirroot . '/filter/poodll/poodllresourcelib.php');
 
 $PAGE->set_context(context_system::instance());


### PR DESCRIPTION
Without this change, the require statement is pointing to an invalid
path. __DIR__ does not have a trailing slash.

If Moodle is accessed through a symlink, its been observed that the
require statement fails, which looks like this:

lib/editor/atto/plugins/poodll/dialog../../../../../../../config.php

You can see the missing slash after the "dialog" folder. On a
non-symlinked path, this just happens to load up the correct file.

This also corrects the number of '../' - the folder is only 6 deep from
config, not 7.